### PR TITLE
Scan and nested properties support.

### DIFF
--- a/src/Attribute.cpp
+++ b/src/Attribute.cpp
@@ -2,7 +2,7 @@
 
 namespace wiphynlcontrol {
 
-Attribute::Attribute(const std::variant<std::string, uint32_t> &val,
+Attribute::Attribute(void *val,
                      const Nl80211AttributeTypes &tp,
                      const ValueTypes &val_type)
     : value(val), type(tp), value_type(val_type) {}

--- a/src/Attribute.cpp
+++ b/src/Attribute.cpp
@@ -4,6 +4,7 @@ namespace wiphynlcontrol {
 
 Attribute::Attribute(void *val,
                      const Nl80211AttributeTypes &tp,
-                     const ValueTypes &val_type)
+                     const ValueTypes &val_type,
+                     const Attribute *parent)
     : value(val), type(tp), value_type(val_type) {}
 }  // namespace wiphynlcontrol

--- a/src/Attribute.cpp
+++ b/src/Attribute.cpp
@@ -5,6 +5,6 @@ namespace wiphynlcontrol {
 Attribute::Attribute(void *val,
                      const Nl80211AttributeTypes &tp,
                      const ValueTypes &val_type,
-                     const Attribute *parent)
-    : value(val), type(tp), value_type(val_type) {}
+                     const Attribute *par)
+    : value(val), type(tp), value_type(val_type), parent(par) {}
 }  // namespace wiphynlcontrol

--- a/src/Attribute.h
+++ b/src/Attribute.h
@@ -8,10 +8,15 @@
 typedef enum nl80211_attrs Nl80211AttributeTypes;
 typedef struct nlattr LibnlAttribute;
 
+typedef struct NestedAttr {
+  struct nlattr **attr;
+  struct nla_policy *policy;
+} NestedAttr;
+
 namespace wiphynlcontrol {
 
 struct Attribute {
-  enum class ValueTypes { UINT32, UINT48, STRING };
+  enum class ValueTypes { UINT32, UINT48, STRING, NESTED_BSS };
   void  *value;
   const Nl80211AttributeTypes type;
   const ValueTypes value_type;

--- a/src/Attribute.h
+++ b/src/Attribute.h
@@ -20,9 +20,11 @@ struct Attribute {
   void  *value;
   const Nl80211AttributeTypes type;
   const ValueTypes value_type;
+  void *parent;
   Attribute(void *val,
             const Nl80211AttributeTypes &tp,
-            const ValueTypes &val_type);
+            const ValueTypes &val_type,
+            const Attribute *parent);
 };
 
 }  // namespace wiphynlcontrol

--- a/src/Attribute.h
+++ b/src/Attribute.h
@@ -4,7 +4,6 @@
 #include <linux/nl80211.h>
 
 #include <string>
-#include <variant>
 
 typedef enum nl80211_attrs Nl80211AttributeTypes;
 typedef struct nlattr LibnlAttribute;
@@ -13,10 +12,10 @@ namespace wiphynlcontrol {
 
 struct Attribute {
   enum class ValueTypes { UINT32, UINT48, STRING };
-  std::variant<std::string, uint32_t> value;
+  void  *value;
   const Nl80211AttributeTypes type;
   const ValueTypes value_type;
-  Attribute(const std::variant<std::string, uint32_t> &val,
+  Attribute(void *val,
             const Nl80211AttributeTypes &tp,
             const ValueTypes &val_type);
 };

--- a/src/Attribute.h
+++ b/src/Attribute.h
@@ -11,7 +11,7 @@ typedef struct nlattr LibnlAttribute;
 typedef struct NestedAttr {
   struct nlattr **attr;
   struct nla_policy *policy;
-} NestedAttr;
+} Scan;
 
 namespace wiphynlcontrol {
 

--- a/src/Attribute.h
+++ b/src/Attribute.h
@@ -16,15 +16,15 @@ typedef struct NestedAttr {
 namespace wiphynlcontrol {
 
 struct Attribute {
-  enum class ValueTypes { UINT32, UINT48, STRING, NESTED_BSS };
+  enum class ValueTypes { UINT32, UINT48, STRING, NESTED };
   void  *value;
   const Nl80211AttributeTypes type;
   const ValueTypes value_type;
-  void *parent;
+  const Attribute *parent;
   Attribute(void *val,
             const Nl80211AttributeTypes &tp,
             const ValueTypes &val_type,
-            const Attribute *parent);
+            const Attribute *par);
 };
 
 }  // namespace wiphynlcontrol

--- a/src/Attribute.h
+++ b/src/Attribute.h
@@ -8,15 +8,17 @@
 typedef enum nl80211_attrs Nl80211AttributeTypes;
 typedef struct nlattr LibnlAttribute;
 
-typedef struct NestedAttr {
-  struct nlattr **attr;
-  struct nla_policy *policy;
-} Scan;
-
 namespace wiphynlcontrol {
 
+typedef struct SSIDInfo {
+  std::string ssid;
+  uint32_t frequency;
+  std::string mac_address;
+  std::string status;
+} SSIDInfo;
+
 struct Attribute {
-  enum class ValueTypes { UINT32, UINT48, STRING, NESTED };
+  enum class ValueTypes { UINT32, UINT48, STRING, NESTED, SCAN };
   void  *value;
   const Nl80211AttributeTypes type;
   const ValueTypes value_type;

--- a/src/Communicator.cpp
+++ b/src/Communicator.cpp
@@ -143,7 +143,8 @@ int Communicator::get_attributes(LibnlMessage *msg,
           if (!it->value) {
             break;
           }
-          *static_cast<uint32_t *>(it->value) = *static_cast<uint32_t *>(attribute_value);
+          *static_cast<uint32_t *>(it->value) =
+              *static_cast<uint32_t *>(attribute_value);
           break;
 
         case Attribute::ValueTypes::UINT48:
@@ -188,8 +189,11 @@ int Communicator::get_attributes(LibnlMessage *msg,
 
           for (uint8_t i = 0; i < NL80211_BSS_MAX + 1; ++i) {
             fprintf(stderr, "i %d!\n", i);
-            std::cout << " and " << static_cast<NestedAttr *>(it->value)->policy[i].type << "\n";
-            if (static_cast<NestedAttr *>(it->value)->policy[i].type > NLA_TYPE_MAX)
+            std::cout << " and "
+                      << static_cast<NestedAttr *>(it->value)->policy[i].type
+                      << "\n";
+            if (static_cast<NestedAttr *>(it->value)->policy[i].type >
+                NLA_TYPE_MAX)
               fprintf(stderr, "Too big!\n");
           }
 
@@ -201,10 +205,12 @@ int Communicator::get_attributes(LibnlMessage *msg,
             break;
           }
 
-          if (!(static_cast<NestedAttr *>(it->value))->attr[NL80211_BSS_BSSID]) {
+          if (!(static_cast<NestedAttr *>(it->value))
+                   ->attr[NL80211_BSS_BSSID]) {
             break;
           }
-          if (!(static_cast<NestedAttr *>(it->value))->attr[NL80211_BSS_STATUS]) {
+          if (!(static_cast<NestedAttr *>(it->value))
+                   ->attr[NL80211_BSS_STATUS]) {
             break;
           }
 
@@ -214,14 +220,15 @@ int Communicator::get_attributes(LibnlMessage *msg,
           std::cout << "Interface " << dev << "\n";
 
           for (uint8_t i = 0; i < NL80211_BSS_MAX + 1; ++i) {
-            struct nlattr *attri = static_cast<NestedAttr *>(it->value)->attr[i];
+            struct nlattr *attri =
+                static_cast<NestedAttr *>(it->value)->attr[i];
             if (!attri) {
               continue;
             }
 
-            void * nested_attribute_value = nla_data(attri);
-            std::cout << "Value: " << *(uint32_t *)nested_attribute_value << "\n";
-
+            void *nested_attribute_value = nla_data(attri);
+            std::cout << "Value: " << *(uint32_t *)nested_attribute_value
+                      << "\n";
           }
 
                     // switch (nla_get_u32(bss[NL80211_BSS_STATUS])) {

--- a/src/Communicator.cpp
+++ b/src/Communicator.cpp
@@ -107,16 +107,21 @@ void Communicator::send_and_receive(LibnlSocket *socket,
 
 int Communicator::get_attributes(LibnlMessage *msg,
                                  const std::vector<Attribute *> *attr_read) {
-  void *attribute_value;
-  LibnlAttribute *attributes[NL80211_ATTR_MAX + 1];
+  void *attribute_to_read_value;
+  int attribute_to_read_type;
+  int attribute_type;  // Type of the attribute cast to int.
+  int result;
+  std::unique_ptr<LibnlAttribute *[]> parent_attributes, nested_attributes;
+  static auto attributes =
+      std::make_unique<LibnlAttribute *[]>(NL80211_ATTR_MAX + 1);
 
 #ifdef COM_DEBUG
   std::cout << "Received ATTRs:\n";
   for (auto type = NL80211_ATTR_UNSPEC; type < NL80211_ATTR_MAX;
        type      = static_cast<Nl80211AttributeTypes>(type + 1)) {
-    attribute_value = nla_data(attributes[type]);
-    if (reinterpret_cast<long>(attribute_value) != 0x4) {
-      std::cout << int(type) << "\t" << attribute_value << std::endl;
+    attribute_to_read_value = nla_data(attributes.get()[type]);
+    if (reinterpret_cast<long>(attribute_to_read_value) != 0x4) {
+      std::cout << int(type) << "\t" << attribute_to_read_value << std::endl;
     }
   }
 #endif
@@ -131,48 +136,65 @@ int Communicator::get_attributes(LibnlMessage *msg,
     return NL_OK;
   }
   // Get message attributes
-  nla_parse(attributes,
+  nla_parse(attributes.get(),
             NL80211_ATTR_MAX,
             genlmsg_attrdata(header, 0),
             genlmsg_attrlen(header, 0),
             NULL);
 
-  LibnlAttribute **parent_attributes = attributes, **nested_attributes;
   const Attribute *attr_top;
   std::vector<const Attribute *> attr_vec;
-  int attribute_type;  // Type of the attribute casted to int.
-
   for (auto &attribute_to_read : *attr_read) {
+    // Push all parents (from bottom to top) to the vector.
     attr_top = attribute_to_read;
     while (attr_top->parent) {
       attr_top = attr_top->parent;
       attr_vec.push_back(attr_top);
       std::cout << "Iteration in attr_top loop \n";
-    }  // Get the parent on the top. It will be obtained from the attributes.
+    }
 
+    // Get the attribute value. The value is true only for not-nested
+    // attributes.
+    attribute_to_read_type = static_cast<int>(attribute_to_read->type);
+    if ((attribute_to_read_type <= NL80211_ATTR_MAX) &&
+        (attributes.get()[attribute_to_read_type])) {
+      attribute_to_read_value =
+          nla_data(parent_attributes[attribute_to_read_type]);
+    }
+
+    // Enter the loop only if nested.
     for (auto i = attr_vec.size(); i > 0; --i) {
-      attribute_type    = static_cast<int>(attr_vec[i - 1]->type);
-      nested_attributes = new LibnlAttribute*[attribute_type];
-      if (nla_parse_nested(nested_attributes, attribute_type,
-                           parent_attributes[attribute_type], NULL) != 0) {
-        if (parent_attributes != attributes) {
-          delete[] parent_attributes;
-        }
-        delete[] nested_attributes;
+      attribute_type = static_cast<int>(attr_vec[i - 1]->type);
+      nested_attributes =
+          std::make_unique<LibnlAttribute *[]>(attribute_type + 1);
+
+      if (i == attr_vec.size()) {
+        result = nla_parse_nested(nested_attributes.get(), attribute_type,
+                                  attributes.get()[attribute_type], NULL);
+      } else {
+        result =
+            nla_parse_nested(nested_attributes.get(), attribute_type,
+                             parent_attributes.get()[attribute_type], NULL);
+      }
+
+      if (result != 0) {
         fprintf(stderr, "failed to parse nested attributes!\n");
         return NL_SKIP;
       }
-      if (parent_attributes != attributes) {
-        std::cout << "Deleted payload " << "\n";
-        delete[] parent_attributes;
-      }
-      parent_attributes = nested_attributes;
-      std::cout << "Iteration " << i << "\n";
-    }
 
-    attribute_type = static_cast<int>(attribute_to_read->type);
-    if (parent_attributes[attribute_type]) {
-      attribute_value = nla_data(parent_attributes[attribute_type]);
+      parent_attributes = std::move(nested_attributes);
+      if (i > 1) {
+        continue;
+      }
+      // Get the attribute value. After last iteration, the value is true for
+      // nested attributes.
+      attribute_to_read_type = static_cast<int>(attribute_to_read->type);
+      if ((attribute_to_read_type <= attribute_type) &&
+          (parent_attributes.get()[attribute_to_read_type])) {
+        attribute_to_read_value =
+            nla_data(parent_attributes[attribute_to_read_type]);
+      }
+      std::cout << "Iteration " << i << "\n";
     }
 
     switch (attribute_to_read->value_type) {
@@ -181,7 +203,7 @@ int Communicator::get_attributes(LibnlMessage *msg,
           break;
         }
         *static_cast<uint32_t *>(attribute_to_read->value) =
-            *static_cast<uint32_t *>(attribute_value);
+            *static_cast<uint32_t *>(attribute_to_read_value);
         break;
 
       case Attribute::ValueTypes::UINT48:
@@ -191,12 +213,12 @@ int Communicator::get_attributes(LibnlMessage *msg,
         char tmp_str[18];
         sprintf(tmp_str,
                 "%02x:%02x:%02x:%02x:%02x:%02x",
-                *(static_cast<const char *>(attribute_value)) & 0xff,
-                *(static_cast<const char *>(attribute_value) + 1) & 0xff,
-                *(static_cast<const char *>(attribute_value) + 2) & 0xff,
-                *(static_cast<const char *>(attribute_value) + 3) & 0xff,
-                *(static_cast<const char *>(attribute_value) + 4) & 0xff,
-                *(static_cast<const char *>(attribute_value) + 5) & 0xff);
+                *(static_cast<const char *>(attribute_to_read_value)) & 0xff,
+                *(static_cast<const char *>(attribute_to_read_value) + 1) & 0xff,
+                *(static_cast<const char *>(attribute_to_read_value) + 2) & 0xff,
+                *(static_cast<const char *>(attribute_to_read_value) + 3) & 0xff,
+                *(static_cast<const char *>(attribute_to_read_value) + 4) & 0xff,
+                *(static_cast<const char *>(attribute_to_read_value) + 5) & 0xff);
         static_cast<std::string *>(attribute_to_read->value)->assign(tmp_str);
         break;
 
@@ -205,81 +227,86 @@ int Communicator::get_attributes(LibnlMessage *msg,
           break;
         }
         static_cast<std::string *>(attribute_to_read->value)->assign(
-                static_cast<const char *>(attribute_value));
+                static_cast<const char *>(attribute_to_read_value));
         break;
 
-      case Attribute::ValueTypes::NESTED:
-        if (!attribute_to_read->value) {
-          break;
-        }
+        // case Attribute::ValueTypes::NESTED:
+        //   if (!attribute_to_read->value) {
+        //     break;
+        //   }
 
-        if (!static_cast<NestedAttr *>(attribute_to_read->value)->attr ||
-            !static_cast<NestedAttr *>(attribute_to_read->value)->policy) {
-          fprintf(stderr, "no policy/attr!\n");
-          break;
-        }
+        //   if (!static_cast<NestedAttr *>(attribute_to_read->value)->attr ||
+        //       !static_cast<NestedAttr *>(attribute_to_read->value)->policy) {
+        //     fprintf(stderr, "no policy/attr!\n");
+        //     break;
+        //   }
 
-        if (!attributes[NL80211_ATTR_BSS]) {
-          fprintf(stderr, "bss info missing!\n");
-          break;
-        }
+        //   if (!attributes.get()[NL80211_ATTR_BSS]) {
+        //     fprintf(stderr, "bss info missing!\n");
+        //     break;
+        //   }
 
-        for (uint8_t i = 0; i < NL80211_BSS_MAX + 1; ++i) {
-          fprintf(stderr, "i %d!\n", i);
-          std::cout << " and "
-                    << static_cast<NestedAttr *>(attribute_to_read->value)->policy[i].type
-                    << "\n";
-          if (static_cast<NestedAttr *>(attribute_to_read->value)->policy[i].type >
-              NLA_TYPE_MAX)
-            fprintf(stderr, "Too big!\n");
-        }
+        //   for (uint8_t i = 0; i < NL80211_BSS_MAX + 1; ++i) {
+        //     fprintf(stderr, "i %d!\n", i);
+        //     std::cout << " and "
+        //               << static_cast<NestedAttr
+        //               *>(attribute_to_read->value)->policy[i].type
+        //               << "\n";
+        //     if (static_cast<NestedAttr
+        //     *>(attribute_to_read->value)->policy[i].type >
+        //         NLA_TYPE_MAX)
+        //       fprintf(stderr, "Too big!\n");
+        //   }
 
-        if (nla_parse_nested(static_cast<NestedAttr *>(attribute_to_read->value)->attr,
-                NL80211_BSS_MAX,
-                attributes[NL80211_ATTR_BSS],
-                static_cast<NestedAttr *>(attribute_to_read->value)->policy)) {
-          fprintf(stderr, "failed to parse nested attributes!\n");
-          break;
-        }
+        //   if (nla_parse_nested(static_cast<NestedAttr
+        //   *>(attribute_to_read->value)->attr,
+        //           NL80211_BSS_MAX,
+        //           attributes.get()[NL80211_ATTR_BSS],
+        //           static_cast<NestedAttr
+        //           *>(attribute_to_read->value)->policy)) {
+        //     fprintf(stderr, "failed to parse nested attributes!\n");
+        //     break;
+        //   }
 
-        if (!(static_cast<NestedAttr *>(attribute_to_read->value))
-                  ->attr[NL80211_BSS_BSSID]) {
-          break;
-        }
-        if (!(static_cast<NestedAttr *>(attribute_to_read->value))
-                  ->attr[NL80211_BSS_STATUS]) {
-          break;
-        }
+        //   if (!(static_cast<NestedAttr *>(attribute_to_read->value))
+        //             ->attr[NL80211_BSS_BSSID]) {
+        //     break;
+        //   }
+        //   if (!(static_cast<NestedAttr *>(attribute_to_read->value))
+        //             ->attr[NL80211_BSS_STATUS]) {
+        //     break;
+        //   }
 
-        // mac_addr_n2a(mac_addr, nla_data(bss[NL80211_BSS_BSSID]));
-        char dev[20];
-        if_indextoname(nla_get_u32(attributes[NL80211_ATTR_IFINDEX]), dev);
-        std::cout << "Interface " << dev << "\n";
+        //   // mac_addr_n2a(mac_addr, nla_data(bss[NL80211_BSS_BSSID]));
+        //   char dev[20];
+        //   if_indextoname(nla_get_u32(attributes.get()[NL80211_ATTR_IFINDEX]),
+        //   dev); std::cout << "Interface " << dev << "\n";
 
-        for (uint8_t i = 0; i < NL80211_BSS_MAX + 1; ++i) {
-          struct nlattr *attri =
-              static_cast<NestedAttr *>(attribute_to_read->value)->attr[i];
-          if (!attri) {
-            continue;
-          }
+        //   for (uint8_t i = 0; i < NL80211_BSS_MAX + 1; ++i) {
+        //     struct nlattr *attri =
+        //         static_cast<NestedAttr *>(attribute_to_read->value)->attr[i];
+        //     if (!attri) {
+        //       continue;
+        //     }
 
-          void *nested_attribute_value = nla_data(attri);
-          std::cout << "Value: " << *(uint32_t *)nested_attribute_value
-                    << "\n";
-        }
+        //     void *nested_attribute_value = nla_data(attri);
+        //     std::cout << "Value: " << *(uint32_t *)nested_attribute_value
+        //               << "\n";
+        //   }
 
-                  // switch (nla_get_u32(bss[NL80211_BSS_STATUS])) {
-                  // case NL80211_BSS_STATUS_ASSOCIATED:
-                  //   printf("Connected to %s (on %s)\n", mac_addr, dev);
-                  //   break;
-                  // case NL80211_BSS_STATUS_AUTHENTICATED:
-                  //   printf("Authenticated with %s (on %s)\n", mac_addr, dev);
-                  //   return NL_SKIP;
-                  // case NL80211_BSS_STATUS_IBSS_JOINED:
-                  //   printf("Joined IBSS %s (on %s)\n", mac_addr, dev);
-                  //   break;
-                  // default:
-                  //   return NL_SKIP;
+        //             // switch (nla_get_u32(bss[NL80211_BSS_STATUS])) {
+        //             // case NL80211_BSS_STATUS_ASSOCIATED:
+        //             //   printf("Connected to %s (on %s)\n", mac_addr, dev);
+        //             //   break;
+        //             // case NL80211_BSS_STATUS_AUTHENTICATED:
+        //             //   printf("Authenticated with %s (on %s)\n", mac_addr,
+        //             dev);
+        //             //   return NL_SKIP;
+        //             // case NL80211_BSS_STATUS_IBSS_JOINED:
+        //             //   printf("Joined IBSS %s (on %s)\n", mac_addr, dev);
+        //             //   break;
+        //             // default:
+        //             //   return NL_SKIP;
 
       default:;
     }

--- a/src/Communicator.cpp
+++ b/src/Communicator.cpp
@@ -105,25 +105,8 @@ void Communicator::send_and_receive(LibnlSocket *socket,
 
 int Communicator::get_attributes(LibnlMessage *msg,
                                  const std::vector<Attribute *> *attr_read) {
-  if (!attr_read) {
-    return NL_OK;  // No attributes was specified to read from message.
-  }
-  // Get message header
-  LibnlGeMessageHeader *header;
-  if (!(header =
-            static_cast<LibnlGeMessageHeader *>(nlmsg_data(nlmsg_hdr(msg))))) {
-    return NL_OK;
-  }
-  // Get message attributes
-  LibnlAttribute *attributes[NL80211_ATTR_MAX + 1];
-  nla_parse(attributes,
-            NL80211_ATTR_MAX,
-            genlmsg_attrdata(header, 0),
-            genlmsg_attrlen(header, 0),
-            NULL);
-
   void *attribute_value;
-
+  LibnlAttribute *attributes[NL80211_ATTR_MAX + 1];
 #ifdef COM_DEBUG
   std::cout << "Received ATTRs:\n";
   for (auto type = NL80211_ATTR_UNSPEC; type < NL80211_ATTR_MAX;
@@ -134,6 +117,22 @@ int Communicator::get_attributes(LibnlMessage *msg,
     }
   }
 #endif
+
+  if (!attr_read) {
+    return NL_OK;  // No attributes was specified to read from message.
+  }
+  // Get message header
+  LibnlGeMessageHeader *header;
+  if (!(header =
+            static_cast<LibnlGeMessageHeader *>(nlmsg_data(nlmsg_hdr(msg))))) {
+    return NL_OK;
+  }
+  // Get message attributes
+  nla_parse(attributes,
+            NL80211_ATTR_MAX,
+            genlmsg_attrdata(header, 0),
+            genlmsg_attrlen(header, 0),
+            NULL);
 
   for (auto &it : *attr_read) {
     if (attributes[it->type]) {

--- a/src/Communicator.cpp
+++ b/src/Communicator.cpp
@@ -147,14 +147,11 @@ int Communicator::get_attributes(LibnlMessage *msg,
   for (auto &attribute_to_read : *attr_read) {
     // Push all parents (from bottom to top) to the vector.
     attr_top = attribute_to_read;
-    std::cout << "Before top loop\n";
-    if (attr_top->parent)
-      std::cout << "attr top if top loop\n";
     while (attr_top->parent) {
-      std::cout << "In top loop\n";
+      // std::cout << "In top loop\n";
       attr_top = attr_top->parent;
       attr_vec.push_back(attr_top);
-      std::cout << "Attr top loop\n";
+      // std::cout << "Attr top loop\n";
     }
     std::cout << "After top loop\n";
     // Get the attribute value. The value is true only for not-nested
@@ -162,7 +159,7 @@ int Communicator::get_attributes(LibnlMessage *msg,
     attribute_to_read_type = static_cast<int>(attribute_to_read->type);
     if ((attribute_to_read_type <= NL80211_ATTR_MAX) &&
         (attributes.get()[attribute_to_read_type])) {
-      std::cout << "attributes get value\n";
+      std::cout << "attributes get value\n" << attribute_to_read_type << "\n";
       attribute_to_read_value =
           nla_data(attributes.get()[attribute_to_read_type]);
     }

--- a/src/Communicator.cpp
+++ b/src/Communicator.cpp
@@ -186,7 +186,6 @@ int Communicator::get_attributes(LibnlMessage *msg,
             break;
           }
 
-          struct nlattr *bss[NL80211_BSS_MAX + 1];
           for (uint8_t i = 0; i < NL80211_BSS_MAX + 1; ++i) {
             fprintf(stderr, "i %d!\n", i);
             std::cout << " and " << static_cast<NestedAttr *>(it->value)->policy[i].type << "\n";
@@ -213,6 +212,17 @@ int Communicator::get_attributes(LibnlMessage *msg,
           char dev[20];
           if_indextoname(nla_get_u32(attributes[NL80211_ATTR_IFINDEX]), dev);
           std::cout << "Interface " << dev << "\n";
+
+          for (uint8_t i = 0; i < NL80211_BSS_MAX + 1; ++i) {
+            struct nlattr *attri = static_cast<NestedAttr *>(it->value)->attr[i];
+            if (!attri) {
+              continue;
+            }
+
+            void * nested_attribute_value = nla_data(attri);
+            std::cout << "Value: " << *(uint32_t *)nested_attribute_value << "\n";
+
+          }
 
                     // switch (nla_get_u32(bss[NL80211_BSS_STATUS])) {
                     // case NL80211_BSS_STATUS_ASSOCIATED:

--- a/src/Communicator.h
+++ b/src/Communicator.h
@@ -12,7 +12,10 @@ namespace wiphynlcontrol {
 
 class Communicator {
  private:
+  enum class ScanTriggerResult {UNSPECIFIED, DONE, ABORTED};
+ private:
   int nl80211_family_id_;
+  int scan_multicast_group_id_;
   CallbackKind socket_cb_kind_;
   LibnlCallback *callback_;
   std::string error_report_;
@@ -27,13 +30,14 @@ class Communicator {
   // Uses the socket to query the kernel for numeric identifier of the
   // Generic Netlink family name. Sets nl80211_family_id_ with the result.
   void set_family_id(LibnlSocket *socket);
+  void set_callback_default();
   // Sends the message_ and gets the answer.
   void send_and_receive(LibnlSocket *socket,
-                        LibnlMessage *message,
-                        const std::vector<Attribute *> *attr_read);
+                        LibnlMessage *message);
   // Gets attributes from the message. Use as callback.
   static int get_attributes(LibnlMessage *msg,
                             const std::vector<Attribute *> *attr_read);
+  static int get_scan_trigger_result(LibnlMessage *msg, ScanTriggerResult *arg);
 
  public:
   // Prepares message and socket. Uses given command and
@@ -45,6 +49,7 @@ class Communicator {
                  const Message::Flags &flags,
                  const std::vector<const Attribute *> *attr_arg,
                  const std::vector<Attribute *> *attr_read);
+  void trigger_scan(int iface_index);
   void set_callback_kind(const CallbackKind &kind);
   const std::string &get_error_report() const;
 

--- a/src/ControlInstance.cpp
+++ b/src/ControlInstance.cpp
@@ -13,40 +13,40 @@
 namespace wiphynlcontrol {
 
 
-// void link_bss() {
-//   int index = 3;
-//   Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
-//   const auto arg = std::vector<const Attribute *>{&attr_arg};
-//   NestedAttr bss_attr_val;
-//   auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED, NULL);
-//   const auto read = std::vector<Attribute *>{&attr_read};
+void link_bss() {
+  int index = 3;
+  Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
+  const auto arg = std::vector<const Attribute *>{&attr_arg};
+  NestedAttr bss_attr_val;
+  auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED, NULL);
+  const auto read = std::vector<Attribute *>{&attr_read};
 
-//   struct nlattr *bss_attr[NL80211_BSS_MAX + 1] = {};
-//   struct nla_policy bss_policy[NL80211_BSS_MAX + 1] = {};
+  // struct nlattr *bss_attr[NL80211_BSS_MAX + 1] = {};
+  // struct nla_policy bss_policy[NL80211_BSS_MAX + 1] = {};
 
-//   bss_policy[NL80211_BSS_TSF] = { type : NLA_U64 };
-//   bss_policy[NL80211_BSS_FREQUENCY] = { type : NLA_U32 };
-//   bss_policy[NL80211_BSS_BSSID] = { };
-//   bss_policy[NL80211_BSS_BEACON_INTERVAL] = { type : NLA_U16 };
-//   bss_policy[NL80211_BSS_CAPABILITY] = { type : NLA_U16 };
-//   bss_policy[NL80211_BSS_INFORMATION_ELEMENTS] = { };
-//   bss_policy[NL80211_BSS_SIGNAL_MBM] = { type : NLA_U32 };
-//   bss_policy[NL80211_BSS_SIGNAL_UNSPEC] = { type : NLA_U8 };
-//   bss_policy[NL80211_BSS_STATUS] = { type : NLA_U32 };
-//   bss_policy[10] = { type : NLA_U32 };
+  // bss_policy[NL80211_BSS_TSF] = { type : NLA_U64 };
+  // bss_policy[NL80211_BSS_FREQUENCY] = { type : NLA_U32 };
+  // bss_policy[NL80211_BSS_BSSID] = { };
+  // bss_policy[NL80211_BSS_BEACON_INTERVAL] = { type : NLA_U16 };
+  // bss_policy[NL80211_BSS_CAPABILITY] = { type : NLA_U16 };
+  // bss_policy[NL80211_BSS_INFORMATION_ELEMENTS] = { };
+  // bss_policy[NL80211_BSS_SIGNAL_MBM] = { type : NLA_U32 };
+  // bss_policy[NL80211_BSS_SIGNAL_UNSPEC] = { type : NLA_U8 };
+  // bss_policy[NL80211_BSS_STATUS] = { type : NLA_U32 };
+  // bss_policy[10] = { type : NLA_U32 };
 
-//   bss_attr_val.attr = &bss_attr[0];
-//   bss_attr_val.policy = &bss_policy[0];
+  // bss_attr_val.attr = &bss_attr[0];
+  // bss_attr_val.policy = &bss_policy[0];
 
-//   ComControl::get_communicator().challenge(NL80211_CMD_GET_SCAN, Message::Flags::DUMP, &arg, &read);
+  ComControl::get_communicator().challenge(NL80211_CMD_TRIGGER_SCAN, Message::Flags::NONE, &arg, &read);
 
-//   Property<NestedAttr> pro(&attr_arg,
-//                             NL80211_ATTR_BSS,
-//                             Attribute::ValueTypes::UINT48,
-//                             NL80211_CMD_GET_SCAN,
-//                             NL80211_CMD_UNSPEC);
+  // Property<NestedAttr> pro(&attr_arg,
+  //                           NL80211_ATTR_BSS,
+  //                           Attribute::ValueTypes::UINT48,
+  //                           NL80211_CMD_GET_SCAN,
+  //                           NL80211_CMD_UNSPEC);
 
-// }
+}
 
 // void station() {
 //     int index = 3;
@@ -90,11 +90,14 @@ class ControlInstance {
       auto wiphy = std::make_shared<Wiphy>(0);
       auto iface = std::make_shared<Interface>(3);
 
-      iface->get();
+
+      // link_bss();
+      // iface->get();
+      ComControl::get_communicator().trigger_scan(iface->index_.value_);
       iface->bss_frequency_.get();
       print_iface(*iface.get());
       // print_wiphy(*wiphy.get());
-      // wiphy->name_.get();
+
       // std::cout << "got name\n";
       // print_wiphy(*wiphy.get());
 
@@ -144,3 +147,4 @@ int main(int argc, char **argv) {
   mynl_base.Main();
   return 0;
 }
+

--- a/src/ControlInstance.cpp
+++ b/src/ControlInstance.cpp
@@ -15,10 +15,10 @@ namespace wiphynlcontrol {
 
 void link_bss() {
   int index = 3;
-  Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32);
+  Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
   const auto arg = std::vector<const Attribute *>{&attr_arg};
   NestedAttr bss_attr_val;
-  auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED_BSS);
+  auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED_BSS, NULL);
   const auto read = std::vector<Attribute *>{&attr_read};
 
   struct nlattr *bss_attr[NL80211_BSS_MAX + 1] = {};
@@ -50,7 +50,7 @@ void link_bss() {
 
 void station() {
     int index = 3;
-    Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32);
+    Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
     const auto arg = std::vector<const Attribute *>{&attr_arg};
     // auto read = Attribute(int(), NL80211_ATTR_BSS, Attribute::ValueTypes::STRING);
     ComControl::get_communicator().challenge(NL80211_CMD_GET_STATION, Message::Flags::DUMP, &arg, NULL);

--- a/src/ControlInstance.cpp
+++ b/src/ControlInstance.cpp
@@ -19,8 +19,8 @@ static void print(const uint32_t &a, const char *args) {
 }
 
 static void print_wiphy(const Wiphy &wiphy) {
-  print(wiphy.index_.get_value(), "index");
-  print(wiphy.name_.get_value(), "name");
+  print(wiphy.index_.value_, "index");
+  print(wiphy.name_.value_, "name");
   // print(*wiphy.bands_, "bands");
   // print(*wiphy.channel_type_, "channel_type");
   // print(*wiphy.txq_params_, "txq_params");
@@ -28,11 +28,11 @@ static void print_wiphy(const Wiphy &wiphy) {
 }
 
 static void print_iface(const Interface &iface) {
-  print(iface.index_.get_value(), "index");
-  print(iface.name_.get_value(), "name");
-  print(iface.type_.get_value(), "interface type");
-  print(iface.mac_addr_.get_value(), "mac addr");
-  print(iface.ssid_.get_value(), "SSID");
+  print(iface.index_.value_, "index");
+  print(iface.name_.value_, "name");
+  print(iface.type_.value_, "interface type");
+  print(iface.mac_addr_.value_, "mac addr");
+  print(iface.ssid_.value_, "SSID");
 }
 
 class ControlInstance {

--- a/src/ControlInstance.cpp
+++ b/src/ControlInstance.cpp
@@ -18,7 +18,7 @@ void link_bss() {
   Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
   const auto arg = std::vector<const Attribute *>{&attr_arg};
   NestedAttr bss_attr_val;
-  auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED_BSS, NULL);
+  auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED, NULL);
   const auto read = std::vector<Attribute *>{&attr_read};
 
   struct nlattr *bss_attr[NL80211_BSS_MAX + 1] = {};
@@ -48,13 +48,13 @@ void link_bss() {
 
 }
 
-void station() {
-    int index = 3;
-    Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
-    const auto arg = std::vector<const Attribute *>{&attr_arg};
-    // auto read = Attribute(int(), NL80211_ATTR_BSS, Attribute::ValueTypes::STRING);
-    ComControl::get_communicator().challenge(NL80211_CMD_GET_STATION, Message::Flags::DUMP, &arg, NULL);
-}
+// void station() {
+//     int index = 3;
+//     Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
+//     const auto arg = std::vector<const Attribute *>{&attr_arg};
+//     // auto read = Attribute(int(), NL80211_ATTR_BSS, Attribute::ValueTypes::STRING);
+//     ComControl::get_communicator().challenge(NL80211_CMD_GET_STATION, Message::Flags::DUMP, &arg, NULL);
+// }
 
 static void print(const std::string &a, const char *args) {
   std::cout << args << ": " << a << '\n';
@@ -87,41 +87,44 @@ class ControlInstance {
     try {
       // Test
       auto wiphy = std::make_shared<Wiphy>(0);
-      auto iface = std::make_shared<Interface>(4);
+      auto iface = std::make_shared<Interface>(3);
 
-      print_wiphy(*wiphy.get());
-      wiphy->name_.get();
-      std::cout << "got name\n";
-      print_wiphy(*wiphy.get());
+      std::cout << "Frequency " << iface->bss_frequency_.get() << "\n";
 
-      wiphy->get();
-      std::cout << "got wiphy\n";
-      print_wiphy(*wiphy.get());
 
-      std::cout << "\n\n\n";
+      // print_wiphy(*wiphy.get());
+      // wiphy->name_.get();
+      // std::cout << "got name\n";
+      // print_wiphy(*wiphy.get());
 
-      iface->mac_addr_.get();
-      std::cout << "got mac\n";
-      print_iface(*iface.get());
+      // wiphy->get();
+      // std::cout << "got wiphy\n";
+      // print_wiphy(*wiphy.get());
 
-      iface->name_.get();
-      std::cout << "got name\n";
-      print_iface(*iface.get());
+      // std::cout << "\n\n\n";
 
-      iface->ssid_.get();
-      std::cout << "got ssid\n";
-      print_iface(*iface.get());
+      // iface->mac_addr_.get();
+      // std::cout << "got mac\n";
+      // print_iface(*iface.get());
 
-      iface->type_.get();
-      std::cout << "got type\n";
-      print_iface(*iface.get());
+      // iface->name_.get();
+      // std::cout << "got name\n";
+      // print_iface(*iface.get());
 
-      auto iface2 = std::make_shared<Interface>(3);
-      iface2->get();
-      std::cout << "got iface\n";
-      print_iface(*iface2.get());
+      // iface->ssid_.get();
+      // std::cout << "got ssid\n";
+      // print_iface(*iface.get());
 
-      link_bss();
+      // iface->type_.get();
+      // std::cout << "got type\n";
+      // print_iface(*iface.get());
+
+      // auto iface2 = std::make_shared<Interface>(3);
+      // iface2->get();
+      // std::cout << "got iface\n";
+      // print_iface(*iface2.get());
+
+      // link_bss();
       // station();
 
     } catch (std::exception &e) {

--- a/src/ControlInstance.cpp
+++ b/src/ControlInstance.cpp
@@ -1,60 +1,13 @@
+// Demonstration of Lib80211Control capabilities.
 
 #include <iostream>
 #include <memory>
-#include <variant>
-
-#include "netlink/attr.h"
 
 #include "ComControl.h"
-#include "Communicator.h"
 #include "Interface.h"
 #include "Wiphy.h"
 
 namespace wiphynlcontrol {
-
-
-void link_bss() {
-  int index = 3;
-  Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
-  const auto arg = std::vector<const Attribute *>{&attr_arg};
-  NestedAttr bss_attr_val;
-  auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED, NULL);
-  const auto read = std::vector<Attribute *>{&attr_read};
-
-  // struct nlattr *bss_attr[NL80211_BSS_MAX + 1] = {};
-  // struct nla_policy bss_policy[NL80211_BSS_MAX + 1] = {};
-
-  // bss_policy[NL80211_BSS_TSF] = { type : NLA_U64 };
-  // bss_policy[NL80211_BSS_FREQUENCY] = { type : NLA_U32 };
-  // bss_policy[NL80211_BSS_BSSID] = { };
-  // bss_policy[NL80211_BSS_BEACON_INTERVAL] = { type : NLA_U16 };
-  // bss_policy[NL80211_BSS_CAPABILITY] = { type : NLA_U16 };
-  // bss_policy[NL80211_BSS_INFORMATION_ELEMENTS] = { };
-  // bss_policy[NL80211_BSS_SIGNAL_MBM] = { type : NLA_U32 };
-  // bss_policy[NL80211_BSS_SIGNAL_UNSPEC] = { type : NLA_U8 };
-  // bss_policy[NL80211_BSS_STATUS] = { type : NLA_U32 };
-  // bss_policy[10] = { type : NLA_U32 };
-
-  // bss_attr_val.attr = &bss_attr[0];
-  // bss_attr_val.policy = &bss_policy[0];
-
-  ComControl::get_communicator().challenge(NL80211_CMD_TRIGGER_SCAN, Message::Flags::NONE, &arg, &read);
-
-  // Property<NestedAttr> pro(&attr_arg,
-  //                           NL80211_ATTR_BSS,
-  //                           Attribute::ValueTypes::UINT48,
-  //                           NL80211_CMD_GET_SCAN,
-  //                           NL80211_CMD_UNSPEC);
-
-}
-
-// void station() {
-//     int index = 3;
-//     Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
-//     const auto arg = std::vector<const Attribute *>{&attr_arg};
-//     // auto read = Attribute(int(), NL80211_ATTR_BSS, Attribute::ValueTypes::STRING);
-//     ComControl::get_communicator().challenge(NL80211_CMD_GET_STATION, Message::Flags::DUMP, &arg, NULL);
-// }
 
 static void print(const std::string &a, const char *args) {
   std::cout << args << ": " << a << '\n';
@@ -67,10 +20,6 @@ static void print(const uint32_t &a, const char *args) {
 static void print_wiphy(const Wiphy &wiphy) {
   print(wiphy.index_.value_, "index");
   print(wiphy.name_.value_, "name");
-  // print(*wiphy.bands_, "bands");
-  // print(*wiphy.channel_type_, "channel_type");
-  // print(*wiphy.txq_params_, "txq_params");
-  // print(*wiphy.frequency_, "frequency");
 }
 
 static void print_iface(const Interface &iface) {
@@ -79,7 +28,6 @@ static void print_iface(const Interface &iface) {
   print(iface.type_.value_, "interface type");
   print(iface.mac_addr_.value_, "mac addr");
   print(iface.ssid_.value_, "SSID");
-  print(iface.bss_frequency_.value_, "Bss frequency");
 }
 
 class ControlInstance {
@@ -90,46 +38,34 @@ class ControlInstance {
       auto wiphy = std::make_shared<Wiphy>(0);
       auto iface = std::make_shared<Interface>(3);
 
+      wiphy->get();
+      std::cout << "got wiphy\n";
+      print_wiphy(*wiphy.get());
 
-      // link_bss();
-      // iface->get();
-      ComControl::get_communicator().trigger_scan(iface->index_.value_);
-      iface->bss_frequency_.get();
+      std::cout << "\n\n\n";
+
+      iface->mac_addr_.get();
+      std::cout << "got mac\n";
+      iface->name_.get();
+      std::cout << "got name\n";
+      iface->ssid_.get();
+      std::cout << "got ssid\n";
+      iface->type_.get();
+      std::cout << "got type\n";
       print_iface(*iface.get());
-      // print_wiphy(*wiphy.get());
 
-      // std::cout << "got name\n";
-      // print_wiphy(*wiphy.get());
+      std::cout << "Trigger scan\n";
+      ComControl::get_communicator().trigger_scan(iface->index_.value_);
+      iface->scan_.get();
+      for (auto &i : iface->scan_.value_) {
+        std::cout << "freq: " << i.frequency << " | mac_addr: " << i.mac_address
+                  << " | ssid: " << i.ssid;
+        if (i.status != "") {
+          std::cout << " | status: " << i.status;
+        }
+        std::cout << "\n";
 
-      // wiphy->get();
-      // std::cout << "got wiphy\n";
-      // print_wiphy(*wiphy.get());
-
-      // std::cout << "\n\n\n";
-
-      // iface->mac_addr_.get();
-      // std::cout << "got mac\n";
-      // print_iface(*iface.get());
-
-      // iface->name_.get();
-      // std::cout << "got name\n";
-      // print_iface(*iface.get());
-
-      // iface->ssid_.get();
-      // std::cout << "got ssid\n";
-      // print_iface(*iface.get());
-
-      // iface->type_.get();
-      // std::cout << "got type\n";
-      // print_iface(*iface.get());
-
-      // auto iface2 = std::make_shared<Interface>(3);
-      // iface2->get();
-      // std::cout << "got iface\n";
-      // print_iface(*iface2.get());
-
-      // link_bss();
-      // station();
+      }
 
     } catch (std::exception &e) {
       std::cout << "Exception: " << e.what() << "\n";
@@ -142,7 +78,6 @@ class ControlInstance {
 }  // namespace wiphynlcontrol
 
 int main(int argc, char **argv) {
-  using namespace wiphynlcontrol;
   wiphynlcontrol::ControlInstance mynl_base;
   mynl_base.Main();
   return 0;

--- a/src/ControlInstance.cpp
+++ b/src/ControlInstance.cpp
@@ -79,6 +79,7 @@ static void print_iface(const Interface &iface) {
   print(iface.type_.value_, "interface type");
   print(iface.mac_addr_.value_, "mac addr");
   print(iface.ssid_.value_, "SSID");
+  print(iface.bss_frequency_.value_, "Bss frequency");
 }
 
 class ControlInstance {
@@ -89,8 +90,9 @@ class ControlInstance {
       auto wiphy = std::make_shared<Wiphy>(0);
       auto iface = std::make_shared<Interface>(3);
 
-      std::cout << "Frequency " << iface->bss_frequency_.get() << "\n";
-
+      // iface->get();
+      // print_iface(*iface.get());
+      iface->name_.get();
 
       // print_wiphy(*wiphy.get());
       // wiphy->name_.get();

--- a/src/ControlInstance.cpp
+++ b/src/ControlInstance.cpp
@@ -13,40 +13,40 @@
 namespace wiphynlcontrol {
 
 
-void link_bss() {
-  int index = 3;
-  Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
-  const auto arg = std::vector<const Attribute *>{&attr_arg};
-  NestedAttr bss_attr_val;
-  auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED, NULL);
-  const auto read = std::vector<Attribute *>{&attr_read};
+// void link_bss() {
+//   int index = 3;
+//   Attribute attr_arg(&index, NL80211_ATTR_IFINDEX, Attribute::ValueTypes::UINT32, NULL);
+//   const auto arg = std::vector<const Attribute *>{&attr_arg};
+//   NestedAttr bss_attr_val;
+//   auto attr_read = Attribute(&bss_attr_val, NL80211_ATTR_BSS, Attribute::ValueTypes::NESTED, NULL);
+//   const auto read = std::vector<Attribute *>{&attr_read};
 
-  struct nlattr *bss_attr[NL80211_BSS_MAX + 1] = {};
-  struct nla_policy bss_policy[NL80211_BSS_MAX + 1] = {};
+//   struct nlattr *bss_attr[NL80211_BSS_MAX + 1] = {};
+//   struct nla_policy bss_policy[NL80211_BSS_MAX + 1] = {};
 
-  bss_policy[NL80211_BSS_TSF] = { type : NLA_U64 };
-  bss_policy[NL80211_BSS_FREQUENCY] = { type : NLA_U32 };
-  bss_policy[NL80211_BSS_BSSID] = { };
-  bss_policy[NL80211_BSS_BEACON_INTERVAL] = { type : NLA_U16 };
-  bss_policy[NL80211_BSS_CAPABILITY] = { type : NLA_U16 };
-  bss_policy[NL80211_BSS_INFORMATION_ELEMENTS] = { };
-  bss_policy[NL80211_BSS_SIGNAL_MBM] = { type : NLA_U32 };
-  bss_policy[NL80211_BSS_SIGNAL_UNSPEC] = { type : NLA_U8 };
-  bss_policy[NL80211_BSS_STATUS] = { type : NLA_U32 };
-  bss_policy[10] = { type : NLA_U32 };
+//   bss_policy[NL80211_BSS_TSF] = { type : NLA_U64 };
+//   bss_policy[NL80211_BSS_FREQUENCY] = { type : NLA_U32 };
+//   bss_policy[NL80211_BSS_BSSID] = { };
+//   bss_policy[NL80211_BSS_BEACON_INTERVAL] = { type : NLA_U16 };
+//   bss_policy[NL80211_BSS_CAPABILITY] = { type : NLA_U16 };
+//   bss_policy[NL80211_BSS_INFORMATION_ELEMENTS] = { };
+//   bss_policy[NL80211_BSS_SIGNAL_MBM] = { type : NLA_U32 };
+//   bss_policy[NL80211_BSS_SIGNAL_UNSPEC] = { type : NLA_U8 };
+//   bss_policy[NL80211_BSS_STATUS] = { type : NLA_U32 };
+//   bss_policy[10] = { type : NLA_U32 };
 
-  bss_attr_val.attr = &bss_attr[0];
-  bss_attr_val.policy = &bss_policy[0];
+//   bss_attr_val.attr = &bss_attr[0];
+//   bss_attr_val.policy = &bss_policy[0];
 
-  ComControl::get_communicator().challenge(NL80211_CMD_GET_SCAN, Message::Flags::DUMP, &arg, &read);
+//   ComControl::get_communicator().challenge(NL80211_CMD_GET_SCAN, Message::Flags::DUMP, &arg, &read);
 
-  Property<NestedAttr> pro(&attr_arg,
-                            NL80211_ATTR_BSS,
-                            Attribute::ValueTypes::UINT48,
-                            NL80211_CMD_GET_SCAN,
-                            NL80211_CMD_UNSPEC);
+//   Property<NestedAttr> pro(&attr_arg,
+//                             NL80211_ATTR_BSS,
+//                             Attribute::ValueTypes::UINT48,
+//                             NL80211_CMD_GET_SCAN,
+//                             NL80211_CMD_UNSPEC);
 
-}
+// }
 
 // void station() {
 //     int index = 3;
@@ -90,10 +90,9 @@ class ControlInstance {
       auto wiphy = std::make_shared<Wiphy>(0);
       auto iface = std::make_shared<Interface>(3);
 
-      // iface->get();
-      // print_iface(*iface.get());
-      iface->name_.get();
-
+      iface->get();
+      iface->bss_frequency_.get();
+      print_iface(*iface.get());
       // print_wiphy(*wiphy.get());
       // wiphy->name_.get();
       // std::cout << "got name\n";

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -11,5 +11,6 @@ Attribute &Entity::get_attribute(Property<T> &prop) const {
 
 template Attribute &Entity::get_attribute(Property<uint32_t> &prop) const;
 template Attribute &Entity::get_attribute(Property<std::string> &prop) const;
+template Attribute &Entity::get_attribute(Property<char> &prop) const;
 
 }  // namespace wiphynlcontrol

--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -1,5 +1,6 @@
 #include "Entity.h"
 
+#include <vector>
 #include "Property.h"
 
 namespace wiphynlcontrol {
@@ -12,5 +13,7 @@ Attribute &Entity::get_attribute(Property<T> &prop) const {
 template Attribute &Entity::get_attribute(Property<uint32_t> &prop) const;
 template Attribute &Entity::get_attribute(Property<std::string> &prop) const;
 template Attribute &Entity::get_attribute(Property<char> &prop) const;
+template Attribute &Entity::get_attribute(
+    Property<std::vector<SSIDInfo>> &prop) const;
 
 }  // namespace wiphynlcontrol

--- a/src/Entity.h
+++ b/src/Entity.h
@@ -18,7 +18,7 @@ class Entity {
 
  public:
   // This member identifies the Entity.
-  virtual const uint32_t &get_identifier() const  = 0;
+  virtual uint32_t get_identifier() const  = 0;
   virtual void set_identifier(const uint32_t &id) = 0;
 };
 

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -23,6 +23,9 @@ const std::string Exception::err_to_str(const int &code) {
     case -19:
       msg.append("No such device");
       break;
+    case -100:
+      msg.append("Network is down");
+      break;
     default:
       msg.append("Unspecified failure");
       break;

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -9,11 +9,7 @@ namespace wiphynlcontrol {
 Interface::Interface(const uint32_t &id)
     : Entity(),
       // Nested Properties (private) - they do not store values.
-      bss_(&get_attribute(index_),
-           NL80211_ATTR_BSS,
-           Attribute::ValueTypes::NESTED,
-           NL80211_CMD_UNSPEC,
-           NL80211_CMD_UNSPEC),
+      // Not implemented any yet.
       // Identifier.
       index_(&get_attribute(index_),
              NL80211_ATTR_IFINDEX,
@@ -41,12 +37,11 @@ Interface::Interface(const uint32_t &id)
             Attribute::ValueTypes::STRING,
             NL80211_CMD_GET_INTERFACE,
             NL80211_CMD_SET_INTERFACE),
-      bss_frequency_ (&get_attribute(index_),
-                      static_cast<Nl80211AttributeTypes>(NL80211_BSS_FREQUENCY),
-                      Attribute::ValueTypes::UINT32,
-                      NL80211_CMD_GET_SCAN,
-                      NL80211_CMD_UNSPEC,
-                      &get_attribute(bss_)),
+      scan_ (&get_attribute(index_),
+             NL80211_ATTR_BSS,
+             Attribute::ValueTypes::SCAN,
+             NL80211_CMD_GET_SCAN,
+             NL80211_CMD_UNSPEC),
       all_attrs({&get_attribute(index_),
                  &get_attribute(name_),
                  &get_attribute(type_),

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -48,8 +48,8 @@ void Interface::get() {
       NL80211_CMD_GET_INTERFACE, Message::Flags::NONE, &attr_args, &attrs);
 }
 
-const uint32_t &Interface::get_identifier() const { return index_.get_value(); }
+uint32_t Interface::get_identifier() const { return index_.value_; }
 
-void Interface::set_identifier(const uint32_t &id) { index_.set_value(id); }
+void Interface::set_identifier(const uint32_t &id) { index_.value_ = id; }
 
 }  // namespace wiphynlcontrol

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -8,11 +8,19 @@ namespace wiphynlcontrol {
 
 Interface::Interface(const uint32_t &id)
     : Entity(),
+      // Nested Properties (private) - they do not store values.
+      bss_(&get_attribute(index_),
+           NL80211_ATTR_BSS,
+           Attribute::ValueTypes::NESTED,
+           NL80211_CMD_UNSPEC,
+           NL80211_CMD_UNSPEC),
+      // Identifier.
       index_(&get_attribute(index_),
              NL80211_ATTR_IFINDEX,
              Attribute::ValueTypes::UINT32,
              NL80211_CMD_GET_INTERFACE,
              NL80211_CMD_SET_INTERFACE),
+      // Properties (public).
       name_(&get_attribute(index_),
             NL80211_ATTR_IFNAME,
             Attribute::ValueTypes::STRING,
@@ -33,11 +41,18 @@ Interface::Interface(const uint32_t &id)
             Attribute::ValueTypes::STRING,
             NL80211_CMD_GET_INTERFACE,
             NL80211_CMD_SET_INTERFACE),
+      bss_frequency_ (&get_attribute(index_),
+                      static_cast<Nl80211AttributeTypes>(NL80211_BSS_FREQUENCY),
+                      Attribute::ValueTypes::UINT32,
+                      NL80211_CMD_GET_SCAN,
+                      NL80211_CMD_UNSPEC,
+                      &get_attribute(bss_)),
       all_attrs({&get_attribute(index_),
                  &get_attribute(name_),
                  &get_attribute(type_),
                  &get_attribute(mac_addr_),
-                 &get_attribute(ssid_)}) {
+                 &get_attribute(ssid_),
+                 &get_attribute(bss_frequency_)}) {
   set_identifier(id);
 }  // namespace wiphynlcontrol
 

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -51,8 +51,7 @@ Interface::Interface(const uint32_t &id)
                  &get_attribute(name_),
                  &get_attribute(type_),
                  &get_attribute(mac_addr_),
-                 &get_attribute(ssid_),
-                 &get_attribute(bss_frequency_)}) {
+                 &get_attribute(ssid_)}) {
   set_identifier(id);
 }  // namespace wiphynlcontrol
 

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -1,7 +1,7 @@
 #ifndef WIPHYNLCONTROL_INTERFACE_H_
 #define WIPHYNLCONTROL_INTERFACE_H_
 
-#define IFACE_ATTR_NUM 6
+#define IFACE_ATTR_NUM 5
 
 #include <array>
 #include <string>

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -29,7 +29,7 @@ class Interface : public Entity {
  public:
   void get();
   // Returns identifier. Overloads abstract method from Entity.
-  const uint32_t &get_identifier() const;
+  uint32_t get_identifier() const;
   // Overloads abstract method from Entity.
   void set_identifier(const uint32_t &id);
 };

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -1,13 +1,14 @@
 #ifndef WIPHYNLCONTROL_INTERFACE_H_
 #define WIPHYNLCONTROL_INTERFACE_H_
 
-#define IFACE_ATTR_NUM 5
-
 #include <array>
 #include <string>
+#include <vector>
 
 #include "Entity.h"
 #include "Property.h"
+
+#define IFACE_ATTR_NUM 5
 
 namespace wiphynlcontrol {
 
@@ -16,8 +17,7 @@ class Interface : public Entity {
   explicit Interface(const uint32_t &id);
 
  private:
-  Property<char>bss_;
-
+  // Not implemented any nested property yet.
  public:
   Property<uint32_t> index_;
   Property<std::string> name_;
@@ -25,7 +25,7 @@ class Interface : public Entity {
   // mac addr stored as %02x:%02x:%02x:%02x:%02x:%02x string
   Property<std::string> mac_addr_;
   Property<std::string> ssid_;
-  Property<uint32_t> bss_frequency_;
+  Property<std::vector<SSIDInfo>> scan_;
 
  private:
   const std::array<struct Attribute *, IFACE_ATTR_NUM> all_attrs;

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -1,7 +1,7 @@
 #ifndef WIPHYNLCONTROL_INTERFACE_H_
 #define WIPHYNLCONTROL_INTERFACE_H_
 
-#define IFACE_ATTR_NUM 5
+#define IFACE_ATTR_NUM 6
 
 #include <array>
 #include <string>
@@ -15,6 +15,9 @@ class Interface : public Entity {
  public:
   explicit Interface(const uint32_t &id);
 
+ private:
+  Property<char>bss_;
+
  public:
   Property<uint32_t> index_;
   Property<std::string> name_;
@@ -22,6 +25,7 @@ class Interface : public Entity {
   // mac addr stored as %02x:%02x:%02x:%02x:%02x:%02x string
   Property<std::string> mac_addr_;
   Property<std::string> ssid_;
+  Property<uint32_t> bss_frequency_;
 
  private:
   const std::array<struct Attribute *, IFACE_ATTR_NUM> all_attrs;

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -13,9 +13,10 @@ Property<T>::Property(const Attribute *owner_id,
                       const Nl80211AttributeTypes &type,
                       const Attribute::ValueTypes &value_type,
                       const Nl80211Commands &cmd_get,
-                      const Nl80211Commands &cmd_set)
+                      const Nl80211Commands &cmd_set,
+                      const Attribute *parent)
     : value_(T()),
-      attr_(&value_, type, value_type),
+      attr_(&value_, type, value_type, parent),
       owner_identifier_(owner_id),
       cmd_get_(cmd_get),
       cmd_set_(cmd_set) {}
@@ -32,7 +33,7 @@ const T &Property<T>::get() {
 template <typename T>
 void Property<T>::set(const T &arg) {
   // Create attribute object with new value.
-  Attribute attr_arg(const_cast<T *>(&arg), attr_.type, attr_.value_type);
+  Attribute attr_arg(const_cast<T *>(&arg), attr_.type, attr_.value_type, NULL);
   // Place the object in the vactor and add to the request for the Communicator.
   const auto attr_args =
       std::vector<const Attribute *>{owner_identifier_, &attr_arg};

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -46,5 +46,6 @@ void Property<T>::set(const T &arg) {
 
 template class Property<uint32_t>;
 template class Property<std::string>;
+template class Property<NestedAttr>;
 
 }  // namespace wiphynlcontrol

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -1,6 +1,7 @@
 #include "Property.h"
 
 #include <string>
+#include <vector>
 
 #include "ComControl.h"
 #include "Exception.h"
@@ -29,8 +30,11 @@ const T &Property<T>::get() {
     ComControl::get_communicator().challenge(cmd_get_, Message::Flags::DUMP,
                                              &attr_args, &attr_read);
   } else {
-  ComControl::get_communicator().challenge(cmd_get_, Message::Flags::NONE,
-                                           &attr_args, &attr_read);
+    ComControl::get_communicator().challenge(cmd_get_, Message::Flags::NONE,
+                                             &attr_args, &attr_read);
+  }
+  if (ComControl::get_global_error_report() != "") {
+    throw Exception("Property:set:error report after challenge call");
   }
   return value_;
 }
@@ -53,6 +57,6 @@ void Property<T>::set(const T &arg) {
 template class Property<uint32_t>;
 template class Property<std::string>;
 template class Property<char>;
-template class Property<NestedAttr>;
+template class Property<std::vector<SSIDInfo>>;
 
 }  // namespace wiphynlcontrol

--- a/src/Property.cpp
+++ b/src/Property.cpp
@@ -25,8 +25,13 @@ template <typename T>
 const T &Property<T>::get() {
   const auto attr_args = std::vector<const Attribute *>{owner_identifier_};
   const auto attr_read = std::vector<Attribute *>{&attr_};
-  ComControl::get_communicator().challenge(
-      cmd_get_, Message::Flags::NONE, &attr_args, &attr_read);
+  if (cmd_get_ == NL80211_CMD_GET_SCAN) {  // Scan must have DUMP flag.
+    ComControl::get_communicator().challenge(cmd_get_, Message::Flags::DUMP,
+                                             &attr_args, &attr_read);
+  } else {
+  ComControl::get_communicator().challenge(cmd_get_, Message::Flags::NONE,
+                                           &attr_args, &attr_read);
+  }
   return value_;
 }
 
@@ -47,6 +52,7 @@ void Property<T>::set(const T &arg) {
 
 template class Property<uint32_t>;
 template class Property<std::string>;
+template class Property<char>;
 template class Property<NestedAttr>;
 
 }  // namespace wiphynlcontrol

--- a/src/Property.h
+++ b/src/Property.h
@@ -28,7 +28,8 @@ class Property {
                     const Nl80211AttributeTypes &type,
                     const Attribute::ValueTypes &value_type,
                     const Nl80211Commands &cmd_get,
-                    const Nl80211Commands &cmd_set);
+                    const Nl80211Commands &cmd_set,
+                    const Attribute *parent = NULL);
 
   // In cases below, query the kernel.
   const T &get();

--- a/src/Property.h
+++ b/src/Property.h
@@ -29,7 +29,7 @@ class Property {
                     const Attribute::ValueTypes &value_type,
                     const Nl80211Commands &cmd_get,
                     const Nl80211Commands &cmd_set,
-                    const Attribute *parent = NULL);
+                    const Attribute *parent = nullptr);
 
   // In cases below, query the kernel.
   const T &get();

--- a/src/Property.h
+++ b/src/Property.h
@@ -14,6 +14,9 @@ template <typename T>
 class Property {
   friend class Entity;
 
+ public:
+  T value_;
+
  private:
   Attribute attr_;
   const Attribute *owner_identifier_;
@@ -27,8 +30,6 @@ class Property {
                     const Nl80211Commands &cmd_get,
                     const Nl80211Commands &cmd_set);
 
-  const T &get_value() const;
-  void set_value(T val);
   // In cases below, query the kernel.
   const T &get();
   void set(const T &arg);

--- a/src/Property.h
+++ b/src/Property.h
@@ -9,7 +9,6 @@ typedef enum nl80211_commands Nl80211Commands;
 
 namespace wiphynlcontrol {
 
-//  Typename should be std::string or uint32_t.
 template <typename T>
 class Property {
   friend class Entity;

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -5,7 +5,6 @@
 #include <netlink/socket.h>
 
 #include <cassert>
-#include <iostream>
 
 #include "Exception.h"
 

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -21,20 +21,20 @@ Socket::Socket(const CallbackKind cb_kind) {
     throw Exception("Socket:Socket:genl_connect:exited with non-zero code");
   }
 
-  try {
-    // Set socket fd option NETLINK_EXT_ACK
-    int option_value = 1;
-    if (setsockopt(nl_socket_get_fd(socket_),
-                   SOL_NETLINK,
-                   NETLINK_EXT_ACK,
-                   &option_value,
-                   sizeof(option_value)) < 0) {
-      throw Exception(append_errno_to_str(
-          "Socket:Socket:setsockopt:setting socket option failed : "));
-    }
-  } catch (const std::exception &e) {
-    // TODO do not put to stderror
-    std::cerr << e.what() << '\n';
+  // Set socket fd option NETLINK_EXT_ACK
+  int option_value = 1;
+  if (setsockopt(nl_socket_get_fd(socket_),
+                  SOL_NETLINK,
+                  NETLINK_EXT_ACK,
+                  &option_value,
+                  sizeof(option_value)) < 0) {
+    throw Exception(append_errno_to_str(
+        "Socket:Socket:setsockopt:setting socket option failed : "));
+  }
+
+  if (nl_socket_set_nonblocking(socket_) < 0) {
+    throw Exception(append_errno_to_str(
+        "Socket:Socket:setsockopt:setting socket nonblocking failed : "));
   }
 
   callback_ = nl_cb_alloc(static_cast<LibnlCallbackKind>(cb_kind));
@@ -55,6 +55,10 @@ void Socket::set_callback(const LibnlCallback *cb) {
   }
 
   nl_socket_set_cb(socket_, callback_);
+}
+
+void Socket::add_membership(const int &group_id) {
+  nl_socket_add_membership(socket_, group_id);
 }
 
 LibnlSocket *Socket::get_socket() const { return socket_; }

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -25,6 +25,7 @@ class Socket {
 
  public:
   void set_callback(const LibnlCallback *cb);
+  void add_membership(const int &group_id);
   LibnlSocket *get_socket() const;
 
  public:

--- a/src/Wiphy.cpp
+++ b/src/Wiphy.cpp
@@ -31,8 +31,8 @@ void Wiphy::get() {
       NL80211_CMD_GET_WIPHY, Message::Flags::NONE, &attr_args, &attrs);
 }
 
-const uint32_t &Wiphy::get_identifier() const { return index_.get_value(); }
+uint32_t Wiphy::get_identifier() const { return index_.value_; }
 
-void Wiphy::set_identifier(const uint32_t &id) { index_.set_value(id); }
+void Wiphy::set_identifier(const uint32_t &id) { index_.value_ = id; }
 
 }  // namespace wiphynlcontrol

--- a/src/Wiphy.h
+++ b/src/Wiphy.h
@@ -25,7 +25,7 @@ class Wiphy : public Entity {
  public:
   void get();
   // Returns identifier. Overloads abstract method from Entity.
-  const uint32_t &get_identifier() const;
+  uint32_t get_identifier() const;
   // Overloads abstract method from Entity.
   void set_identifier(const uint32_t &id);
 };

--- a/src/Wiphy.h
+++ b/src/Wiphy.h
@@ -1,13 +1,13 @@
 #ifndef WIPHYNLCONTROL_WIPHY_H_
 #define WIPHYNLCONTROL_WIPHY_H_
 
-#define WIPHY_ATTR_NUM 2
-
 #include <array>
 #include <string>
 
 #include "Entity.h"
 #include "Property.h"
+
+#define WIPHY_ATTR_NUM 2
 
 namespace wiphynlcontrol {
 


### PR DESCRIPTION
* Added trigger_scan() function. 
* Added Scan Property with new type (SSIDInfo). It contains scan results, generated with the trigger_scan method.
* Added parent Attribute field. That enables nested Properties.
* Added processing method for Properties with parents in get_attribute() callback.
* Attribute value field is now a pointer to the Property value_ member. Std::variant is no longer used.
*  Moved some Communicator functionalities to new functions (setting callbacks, mac address to string, ssid to string).
* set_family_id() from Communicator now additionally queries for scan group id.
* Added add_membership Socket method. It can be used to join to multicast group.
* Changed all socket types to nonblocking.
